### PR TITLE
fix(template): Rename parameter for indent filter indentfirst to first

### DIFF
--- a/templates/exim.conf.j2
+++ b/templates/exim.conf.j2
@@ -19,7 +19,7 @@
 
 begin acl
 
-{{ exim_acls_section | default("") | indent( width=8, indentfirst=True) }}
+{{ exim_acls_section | default("") | indent( width=8, first=True) }}
 
 ######################################################################
 #                     ROUTERS CONFIGURATION                          #
@@ -27,7 +27,7 @@ begin acl
 
 begin routers
 
-{{ exim_router_section | default("") | indent( width=8, indentfirst=True) }}
+{{ exim_router_section | default("") | indent( width=8, first=True) }}
 
 ######################################################################
 #                     TRANSPORTS CONFIGURATION                       #
@@ -35,7 +35,7 @@ begin routers
 
 begin transports
 
-{{ exim_transport_section | default("") | indent( width=8, indentfirst=True) }}
+{{ exim_transport_section | default("") | indent( width=8, first=True) }}
 
 ######################################################################
 #                     AUTHENTICATORS CONFIGURATION                   #
@@ -43,7 +43,7 @@ begin transports
 
 begin authenticators
 
-{{ exim_authenticator_section | default("") | indent( width=8, indentfirst=True) }}
+{{ exim_authenticator_section | default("") | indent( width=8, first=True) }}
 
 ######################################################################
 #                     REWRITE CONFIGURATION                          #
@@ -51,7 +51,7 @@ begin authenticators
 
 begin rewrite
 
-{{ exim_rewrite_section | default("") | indent( width=8, indentfirst=True) }}
+{{ exim_rewrite_section | default("") | indent( width=8, first=True) }}
 
 ######################################################################
 #                     RETRY CONFIGURATION                          #
@@ -59,5 +59,4 @@ begin rewrite
 
 begin retry
 
-{{ exim_retry_section | default("") | indent( width=8, indentfirst=True) }}
-
+{{ exim_retry_section | default("") | indent( width=8, first=True) }}


### PR DESCRIPTION
The parameter was officially renamed in jinja2 2.10
The old parameter worked until jinja2 3.0, where it was removed